### PR TITLE
Update version to 6.9.3-5

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -15,7 +15,7 @@ CACHE_FILE="$CACHE_DIR/imagemagick.tar.gz"
 
 if [ ! -f $CACHE_FILE ]; then
   # install imagemagick
-  IMAGE_MAGICK_VERSION="${IMAGE_MAGICK_VERSION:-6.9.3-4}"
+  IMAGE_MAGICK_VERSION="${IMAGE_MAGICK_VERSION:-6.9.3-5}"
   IMAGE_MAGICK_FILE="ImageMagick-$IMAGE_MAGICK_VERSION.tar.gz"
   IMAGE_MAGICK_DIR="ImageMagick-$IMAGE_MAGICK_VERSION"
   # SSL cert used on imagemagick not recognized by heroku.


### PR DESCRIPTION
## Problem
`6.9.3-4` doesn't exist on imagemagick's servers anymore. 

```
heroku-buildpack-imagemagick (master) $ curl http://www.imagemagick.org/download/releases/ImageMagick-6.9.3-4.tar.gz
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>404 Not Found</title>
</head><body>
<h1>Not Found</h1>
<p>The requested URL /download/releases/ImageMagick-6.9.3-4.tar.gz was not found on this server.</p>
</body></html>
```

## Solution
Bump imagemagick version to 6.9.3-5

@jayzes 