### PR TITLE
Increment to latest 6.x release and change binary extension from .tar.gz to .tar.xz

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-export `heroku config -s`
-
 indent() {
   sed -u 's/^/       /'
 }

--- a/bin/compile
+++ b/bin/compile
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+export `heroku config -s`
+
 indent() {
   sed -u 's/^/       /'
 }
@@ -12,7 +14,7 @@ VENDOR_DIR="$BUILD_DIR/vendor"
 mkdir -p $VENDOR_DIR
 INSTALL_DIR="$VENDOR_DIR/imagemagick"
 mkdir -p $INSTALL_DIR
-IMAGE_MAGICK_VERSION="${IMAGE_MAGICK_VERSION:-6.9.5-8}"
+IMAGE_MAGICK_VERSION="${IMAGE_MAGICK_VERSION:-6.9.5-9}"
 CACHE_FILE="$CACHE_DIR/imagemagick-$IMAGE_MAGICK_VERSION.tar.gz"
 
 if [ ! -f $CACHE_FILE ]; then

--- a/bin/compile
+++ b/bin/compile
@@ -19,7 +19,7 @@ CACHE_FILE="$CACHE_DIR/imagemagick-$IMAGE_MAGICK_VERSION.tar.gz"
 
 if [ ! -f $CACHE_FILE ]; then
   # install imagemagick
-  IMAGE_MAGICK_FILE="ImageMagick-$IMAGE_MAGICK_VERSION.tar.gz"
+  IMAGE_MAGICK_FILE="ImageMagick-$IMAGE_MAGICK_VERSION.tar.xz"
   IMAGE_MAGICK_DIR="ImageMagick-$IMAGE_MAGICK_VERSION"
   # SSL cert used on imagemagick not recognized by heroku.
   IMAGE_MAGICK_URL="http://www.imagemagick.org/download/releases/$IMAGE_MAGICK_FILE"


### PR DESCRIPTION
I was having trouble deploying my app since the buildpack couldn't find the binary on the server. Turns out that the binaries don't have a .tar.gz extension anymore. Not sure how recent this change is. I tested this and it works.