### PR TITLE
Allow use of Heroku config for ImageMagick version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,15 @@ heroku-buildpack-imagemagick
 =================================
 
 This is a [Heroku buildpack](http://devcenter.heroku.com/articles/buildpacks) for vendoring the ImageMagick binaries into your project.
+
+## Note on Heroku config
+
+Optionally, set the ImageMagick version in a Heroku config like this:
+
+```
+heroku config:set IMAGE_MAGICK_VERSION=7.0.5-0
+```
+
+Make sure the version you're referencing exists on as a `.tar.xz` file amon the [ImageMagic releases](http://www.imagemagick.org/download/releases/).
+
+(Buildpack developer note: the config setting does not show up in the compile script as an environment variable, and has to be read from a file in `$3`, as explained in the [Heroku buildpack docs](https://devcenter.heroku.com/articles/buildpack-api#bin-compile-summary).)

--- a/bin/compile
+++ b/bin/compile
@@ -8,11 +8,21 @@ echo "-----> Install ImageMagick"
 
 BUILD_DIR=$1
 CACHE_DIR=$2
+ENV_DIR=$3
 VENDOR_DIR="$BUILD_DIR/vendor"
 mkdir -p $VENDOR_DIR
 INSTALL_DIR="$VENDOR_DIR/imagemagick"
 mkdir -p $INSTALL_DIR
-IMAGE_MAGICK_VERSION="${IMAGE_MAGICK_VERSION:-6.9.5-10}"
+if [ -d $ENV_DIR ]; then
+  ENV_FILE = "$ENV_DIR/IMAGE_MAGICK_VERSION"
+  if [ -f $ENV_FILE ]; then
+    IMAGE_MAGICK_VERSION="`cat $ENV_FILE`"
+  else
+    IMAGE_MAGICK_VERSION="6.9.5-10"
+  fi
+else
+  IMAGE_MAGICK_VERSION="6.9.5-10"
+fi  
 CACHE_FILE="$CACHE_DIR/imagemagick-$IMAGE_MAGICK_VERSION.tar.gz"
 
 if [ ! -f $CACHE_FILE ]; then

--- a/bin/compile
+++ b/bin/compile
@@ -14,7 +14,7 @@ mkdir -p $VENDOR_DIR
 INSTALL_DIR="$VENDOR_DIR/imagemagick"
 mkdir -p $INSTALL_DIR
 if [ -d $ENV_DIR ]; then
-  ENV_FILE = "$ENV_DIR/IMAGE_MAGICK_VERSION"
+  ENV_FILE="$ENV_DIR/IMAGE_MAGICK_VERSION"
   if [ -f $ENV_FILE ]; then
     IMAGE_MAGICK_VERSION="`cat $ENV_FILE`"
   else
@@ -22,7 +22,7 @@ if [ -d $ENV_DIR ]; then
   fi
 else
   IMAGE_MAGICK_VERSION="6.9.5-10"
-fi  
+fi
 CACHE_FILE="$CACHE_DIR/imagemagick-$IMAGE_MAGICK_VERSION.tar.gz"
 
 if [ ! -f $CACHE_FILE ]; then


### PR DESCRIPTION
Allows you to set the `IMAGE_MAGICK_VERSION` in Heroku config and it will work.

(Previous implementation assumed that config settings appear as environment variables to build packs, but they are actually exposed in a set of files in the ENV_VAR parameter, as per Heroku docs.)