### PR TITLE
Install libgvc6 for cedar-16

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -54,6 +54,9 @@ if [ ! -f $CACHE_FILE ]; then
    echo "    * $p"
    install "$base_url/$p" "$1/$install_dir"
   done
+  
+  echo "Dependencies installed at: $1/$install_dir"
+  
 
   echo "-----> Building ImageMagick"
   cd $IMAGE_MAGICK_DIR
@@ -92,9 +95,10 @@ EOF
 echo "-----> Updating environment variables"
 PROFILE_PATH="$BUILD_DIR/.profile.d/imagemagick.sh"
 ACTUAL_INSTALL_PATH="$HOME/vendor/imagemagick"
+DEPENDENCY_INSTALL_PATH="$HOME/heroku-buildpack-imagemagick/usr/lib"
 mkdir -p $(dirname $PROFILE_PATH)
 echo "export PATH=$ACTUAL_INSTALL_PATH/bin:\$PATH" >> $PROFILE_PATH
-echo "export LD_LIBRARY_PATH=$ACTUAL_INSTALL_PATH/lib:\$LD_LIBRARY_PATH" >> $PROFILE_PATH
+echo "export LD_LIBRARY_PATH=$DEPENDENCY_INSTALL_PATH:\$ACTUAL_INSTALL_PATH/lib:\$LD_LIBRARY_PATH" >> $PROFILE_PATH
 echo "export MAGICK_CONFIGURE_PATH=$ACTUAL_INSTALL_PATH" >> $PROFILE_PATH
 
 # DOWNLOAD_URL="http://www.imagemagick.org/download/ImageMagick-6.9.2-0.tar.gz"

--- a/bin/compile
+++ b/bin/compile
@@ -13,7 +13,8 @@ mkdir -p $VENDOR_DIR
 INSTALL_DIR="$VENDOR_DIR/imagemagick"
 mkdir -p $INSTALL_DIR
 IMAGE_MAGICK_VERSION="${IMAGE_MAGICK_VERSION:-6.9.5-10}"
-CACHE_FILE="$CACHE_DIR/imagemagick-$IMAGE_MAGICK_VERSION.tar.gz"
+# CACHE_FILE="$CACHE_DIR/imagemagick-$IMAGE_MAGICK_VERSION.tar.gz" # uncomment this line when ready to cache again
+CACHE_FILE="$CACHE_DIR/imagemagick-cache-buster-$IMAGE_MAGICK_VERSION.tar.gz"
 
 if [ ! -f $CACHE_FILE ]; then
   # install imagemagick

--- a/bin/compile
+++ b/bin/compile
@@ -51,7 +51,7 @@ if [ ! -f $CACHE_FILE ]; then
   base_url="http://archive.ubuntu.com/ubuntu/pool/main/g/graphviz"
   echo "Installing the following packages:"
   for p in "${packages[@]}"; do
-   echo "    * $p" | i
+   echo "    * $p"
    install "$base_url/$p" "$1/$install_dir"
   done
 

--- a/bin/compile
+++ b/bin/compile
@@ -60,15 +60,15 @@ if [ ! -f $CACHE_FILE ]; then
   
   echo "Dependencies installed at: $1/$install_dir"
   
-#
- # echo "-----> Building ImageMagick"
+
+  echo "-----> Building ImageMagick"
   cd $IMAGE_MAGICK_DIR
- # export CPPFLAGS="-I$INSTALL_DIR/include"
- # export LDFLAGS="-L$INSTALL_DIR/lib"
- # ./configure --prefix=$INSTALL_DIR
- # make && make install
+  export CPPFLAGS="-I$INSTALL_DIR/include"
+  export LDFLAGS="-L$INSTALL_DIR/lib"
+  ./configure --prefix=$INSTALL_DIR
+  make && make install
   cd ..
- # rm -rf $IMAGE_MAGICK_DIR
+  rm -rf $IMAGE_MAGICK_DIR
 
   # cache for future deploys
   echo "-----> Caching ImageMagick installation"

--- a/bin/compile
+++ b/bin/compile
@@ -60,15 +60,15 @@ if [ ! -f $CACHE_FILE ]; then
   
   echo "Dependencies installed at: $1/$install_dir"
   
-
-  echo "-----> Building ImageMagick"
+#
+ # echo "-----> Building ImageMagick"
   cd $IMAGE_MAGICK_DIR
-  export CPPFLAGS="-I$INSTALL_DIR/include"
-  export LDFLAGS="-L$INSTALL_DIR/lib"
-  ./configure --prefix=$INSTALL_DIR
-  make && make install
+ # export CPPFLAGS="-I$INSTALL_DIR/include"
+ # export LDFLAGS="-L$INSTALL_DIR/lib"
+ # ./configure --prefix=$INSTALL_DIR
+ # make && make install
   cd ..
-  rm -rf $IMAGE_MAGICK_DIR
+ # rm -rf $IMAGE_MAGICK_DIR
 
   # cache for future deploys
   echo "-----> Caching ImageMagick installation"
@@ -79,6 +79,8 @@ if [ ! -f $CACHE_FILE ]; then
   
   echo Current Directory
   ls
+  file $REL_INSTALL_DIR.tar.gz
+  file $CACHE_FILE
   echo "About to move rel_install_dir.tar.gz to cache_file ($REL_INSTALL_DIR.tar.giz -- $CACHE_FILE)"
   mv $REL_INSTALL_DIR.tar.gz $CACHE_FILE
 

--- a/bin/compile
+++ b/bin/compile
@@ -14,7 +14,7 @@ INSTALL_DIR="$VENDOR_DIR/imagemagick"
 mkdir -p $INSTALL_DIR
 IMAGE_MAGICK_VERSION="${IMAGE_MAGICK_VERSION:-6.9.5-10}"
 # CACHE_FILE="$CACHE_DIR/imagemagick-$IMAGE_MAGICK_VERSION.tar.gz" # uncomment this line when ready to cache again
-CACHE_FILE="$CACHE_DIR/imagemagick-cache-buster2-$IMAGE_MAGICK_VERSION.tar.gz"
+CACHE_FILE="$CACHE_DIR/imagemagick-cache-buster3-$IMAGE_MAGICK_VERSION.tar.gz"
 
 if [ ! -f $CACHE_FILE ]; then
   # install imagemagick

--- a/bin/compile
+++ b/bin/compile
@@ -49,7 +49,7 @@ if [ ! -f $CACHE_FILE ]; then
   mkdir -p "$1/$install_dir"
  
   base_url="http://archive.ubuntu.com/ubuntu/pool/main/g/graphviz"
-  echo "Installing the following packages:" | a
+  echo "Installing the following packages:"
   for p in "${packages[@]}"; do
    echo "    * $p" | i
    install "$base_url/$p" "$1/$install_dir"

--- a/bin/compile
+++ b/bin/compile
@@ -13,8 +13,7 @@ mkdir -p $VENDOR_DIR
 INSTALL_DIR="$VENDOR_DIR/imagemagick"
 mkdir -p $INSTALL_DIR
 IMAGE_MAGICK_VERSION="${IMAGE_MAGICK_VERSION:-6.9.5-10}"
-# CACHE_FILE="$CACHE_DIR/imagemagick-$IMAGE_MAGICK_VERSION.tar.gz" # uncomment this line when ready to cache again
-CACHE_FILE="$CACHE_DIR/imagemagick-cache-buster3-$IMAGE_MAGICK_VERSION.tar.gz"
+CACHE_FILE="$CACHE_DIR/imagemagick-$IMAGE_MAGICK_VERSION.tar.gz"
 
 if [ ! -f $CACHE_FILE ]; then
   # install imagemagick

--- a/bin/compile
+++ b/bin/compile
@@ -32,6 +32,27 @@ if [ ! -f $CACHE_FILE ]; then
     exit 1;
   fi
   tar xvf $BUILD_DIR/$IMAGE_MAGICK_FILE | indent
+  
+  echo "-----> Downloading dependencies"
+  # This section shamelessly stolen from https://github.com/weibeld/heroku-buildpack-graphviz/commit/8054a8ef7ce41952a54e6d55a6652509ba08dc8d?diff=unified
+ 
+  install() {
+    curl -s "$1" >pkg.deb
+    dpkg -x pkg.deb "$2"
+    rm pkg.deb
+  }
+ 
+  packages = libgvc6_2.38.0-12ubuntu2_amd64.deb ;;
+  
+  install_dir=heroku-buildpack-imagemagick
+  mkdir -p "$1/$install_dir"
+ 
+  base_url="http://archive.ubuntu.com/ubuntu/pool/main/g/graphviz"
+  echo "Installing the following packages:" | a
+  for p in "${packages[@]}"; do
+   echo "    * $p" | i
+   install "$base_url/$p" "$1/$install_dir"
+  done
 
   echo "-----> Building ImageMagick"
   cd $IMAGE_MAGICK_DIR

--- a/bin/compile
+++ b/bin/compile
@@ -14,7 +14,7 @@ INSTALL_DIR="$VENDOR_DIR/imagemagick"
 mkdir -p $INSTALL_DIR
 IMAGE_MAGICK_VERSION="${IMAGE_MAGICK_VERSION:-6.9.5-10}"
 # CACHE_FILE="$CACHE_DIR/imagemagick-$IMAGE_MAGICK_VERSION.tar.gz" # uncomment this line when ready to cache again
-CACHE_FILE="$CACHE_DIR/imagemagick-cache-buster-$IMAGE_MAGICK_VERSION.tar.gz"
+CACHE_FILE="$CACHE_DIR/imagemagick-cache-buster2-$IMAGE_MAGICK_VERSION.tar.gz"
 
 if [ ! -f $CACHE_FILE ]; then
   # install imagemagick
@@ -43,7 +43,7 @@ if [ ! -f $CACHE_FILE ]; then
     rm pkg.deb
   }
  
-  packages = libgvc6_2.38.0-12ubuntu2_amd64.deb
+  packages=libgvc6_2.38.0-12ubuntu2_amd64.deb
   
   install_dir=heroku-buildpack-imagemagick
   mkdir -p "$1/$install_dir"

--- a/bin/compile
+++ b/bin/compile
@@ -15,6 +15,10 @@ mkdir -p $INSTALL_DIR
 IMAGE_MAGICK_VERSION="${IMAGE_MAGICK_VERSION:-6.9.5-10}"
 CACHE_FILE="$CACHE_DIR/imagemagick-$IMAGE_MAGICK_VERSION.tar.gz"
 
+echo "First Argument: $1"
+echo "Second Argument: $2"
+echo "Cache file: $CACHE_FILE"
+
 if [ ! -f $CACHE_FILE ]; then
   # install imagemagick
   IMAGE_MAGICK_FILE="ImageMagick-$IMAGE_MAGICK_VERSION.tar.xz"
@@ -71,6 +75,11 @@ if [ ! -f $CACHE_FILE ]; then
   cd $VENDOR_DIR
   REL_INSTALL_DIR="imagemagick"
   tar czf $REL_INSTALL_DIR.tar.gz $REL_INSTALL_DIR
+  
+  
+  echo Current Directory
+  ls
+  echo "About to move rel_install_dir.tar.gz to cache_file ($REL_INSTALL_DIR.tar.giz -- $CACHE_FILE)"
   mv $REL_INSTALL_DIR.tar.gz $CACHE_FILE
 
 else

--- a/bin/compile
+++ b/bin/compile
@@ -42,7 +42,7 @@ if [ ! -f $CACHE_FILE ]; then
     rm pkg.deb
   }
  
-  packages = libgvc6_2.38.0-12ubuntu2_amd64.deb ;;
+  packages = libgvc6_2.38.0-12ubuntu2_amd64.deb
   
   install_dir=heroku-buildpack-imagemagick
   mkdir -p "$1/$install_dir"


### PR DESCRIPTION
Hello!

I was using this buildpack on Heroku and running in to issues with libgvc6.so not being present (or able to be located properly).

I stole some of https://github.com/weibeld/heroku-buildpack-graphviz to manage installing that dependency, as well as adding the install directory to the `LD_LIBRARY` variable. After doing that, imagemagick was working properly for me on Heroku.

(It's completely possible that I had a different issue or that `libgvc6.so` is actually present on Heroku Cedar-16 and I just didn't configure something properly - I wasn't able to find any concrete documentation on whether that library was pre-installed or not, but I can confirm that this PR is working properly on my own app).