### PR TITLE
Resolve $HOME in profile.d at runtime rather than during the build

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -69,11 +69,11 @@ EOF
 # update PATH and LD_LIBRARY_PATH
 echo "-----> Updating environment variables"
 PROFILE_PATH="$BUILD_DIR/.profile.d/imagemagick.sh"
-ACTUAL_INSTALL_PATH="$HOME/vendor/imagemagick"
+RUNTIME_INSTALL_PATH="\$HOME/vendor/imagemagick"
 mkdir -p $(dirname $PROFILE_PATH)
-echo "export PATH=$ACTUAL_INSTALL_PATH/bin:\$PATH" >> $PROFILE_PATH
-echo "export LD_LIBRARY_PATH=$ACTUAL_INSTALL_PATH/lib:\$LD_LIBRARY_PATH" >> $PROFILE_PATH
-echo "export MAGICK_CONFIGURE_PATH=$ACTUAL_INSTALL_PATH" >> $PROFILE_PATH
+echo "export PATH=$RUNTIME_INSTALL_PATH/bin:\$PATH" >> $PROFILE_PATH
+echo "export LD_LIBRARY_PATH=$RUNTIME_INSTALL_PATH/lib:\$LD_LIBRARY_PATH" >> $PROFILE_PATH
+echo "export MAGICK_CONFIGURE_PATH=$RUNTIME_INSTALL_PATH" >> $PROFILE_PATH
 
 # DOWNLOAD_URL="http://www.imagemagick.org/download/ImageMagick-6.9.2-0.tar.gz"
 


### PR DESCRIPTION
Previously the value for `$HOME` was resolved at build time, meaning its actual value during the build is hardcoded in the `.profile.d/` script, rather than just the variable name.

Whilst the value for `$HOME` is currently the same at both build-time and run-time (both `/app`), the build-time value (only) is due to change in the future to a path under `/tmp`, which would cause this buildpack to break.

By escaping the dollar sign, the variable `$HOME` is now resolved at runtime, making the buildpack compatible with this future change.